### PR TITLE
fix: Class matrix now is "matrix" "array" and length wasn't supported 

### DIFF
--- a/pRRophetic/R/compute_phenotype_function.R
+++ b/pRRophetic/R/compute_phenotype_function.R
@@ -32,9 +32,9 @@ calcPhenotype <- function(trainingExprData, trainingPtype, testExprData, batchCo
 {
   
   # check if the supplied data are of the correct classes
-  if(class(testExprData) != "matrix") stop("ERROR: \"testExprData\" must be a matrix.");
-  if(class(trainingExprData) != "matrix") stop("ERROR: \"trainingExprData\" must be a matrix.");
-  if(class(trainingPtype) != "numeric") stop("ERROR: \"trainingPtype\" must be a numeric vector.");
+  # if(class(testExprData) != "matrix") stop("ERROR: \"testExprData\" must be a matrix.");
+  # if(class(trainingExprData) != "matrix") stop("ERROR: \"trainingExprData\" must be a matrix.");
+  # if(class(trainingPtype) != "numeric") stop("ERROR: \"trainingPtype\" must be a numeric vector.");
   if(ncol(trainingExprData) != length(trainingPtype)) stop("The training phenotype must be of the same length as the number of columns of the training expressin matrix.");
   
   # check if an adequate number of training and test samples have been supplied.

--- a/pRRophetic/R/compute_phenotype_function.R
+++ b/pRRophetic/R/compute_phenotype_function.R
@@ -32,9 +32,9 @@ calcPhenotype <- function(trainingExprData, trainingPtype, testExprData, batchCo
 {
   
   # check if the supplied data are of the correct classes
-  # if(class(testExprData) != "matrix") stop("ERROR: \"testExprData\" must be a matrix.");
-  # if(class(trainingExprData) != "matrix") stop("ERROR: \"trainingExprData\" must be a matrix.");
-  # if(class(trainingPtype) != "numeric") stop("ERROR: \"trainingPtype\" must be a numeric vector.");
+  if(class(testExprData)[1] != "matrix") stop("ERROR: \"testExprData\" must be a matrix.");
+  if(class(trainingExprData)[1] != "matrix") stop("ERROR: \"trainingExprData\" must be a matrix.");
+  if(class(trainingPtype)[1] != "numeric") stop("ERROR: \"trainingPtype\" must be a numeric vector.");
   if(ncol(trainingExprData) != length(trainingPtype)) stop("The training phenotype must be of the same length as the number of columns of the training expressin matrix.");
   
   # check if an adequate number of training and test samples have been supplied.
@@ -85,7 +85,7 @@ calcPhenotype <- function(trainingExprData, trainingPtype, testExprData, batchCo
   # predict the new phenotype for the test data.
   # if there is a single test sample, there may be problems in predicting using the predict() function for the linearRidge package
   # This "if" statement provides a workaround
-  if(class(homData$test) == "numeric")
+  if(class(homData$test)[1] == "numeric")
   {
     n <- names(homData$test)
     homData$test <- matrix(homData$test, ncol=1)


### PR DESCRIPTION
## Description ##

After trying to run the function pRRopheticPredict in my R 4.3.1 version, I got an error concerning my input file not being a matrix, although it was. I have found out this was due to a change in R matrix class that now was "matrix" "array", a vector of length 2. 
Therefore, I fixed this error to be able to run the package locally (I have actually fixed it in the tar.gz file), and it worked perfectly. 

## Technical details ## 

I have selected only the first element to be tested in the if clause concerning it's class.

## Tests ##

Modify this function in the tar.gz file R folder, delete R.zip, zip compress R folder, compress package folder, and install it in R. 
Run the function pRRopheticPredict with a gene expression matrix. 